### PR TITLE
Removing specific error class from #validate_client_options test

### DIFF
--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -398,7 +398,7 @@ describe Vra::Client do
   describe '#validate_client_options!' do
     context 'when all required options are supplied' do
       it 'does not raise an exception' do
-        expect { client.validate_client_options! }.not_to raise_error(ArgumentError)
+        expect { client.validate_client_options! }.not_to raise_error
       end
     end
 


### PR DESCRIPTION
Rspec is warning about this potentially causing false positives,
so the specific error class in the raise_error call has been
removed.

@chef-partners/partner-engineering +1's, please :)