### PR TITLE
Adding masking of passwords in console output

### DIFF
--- a/lib/vra/client.rb
+++ b/lib/vra/client.rb
@@ -70,7 +70,7 @@ module Vra
       headers = {}
       headers['Accept']        = 'application/json'
       headers['Content-Type']  = 'application/json'
-      headers['Authorization'] = "Bearer #{@bearer_token.value}" unless @bearer_token.nil?
+      headers['Authorization'] = "Bearer #{@bearer_token.value}" unless @bearer_token.value.nil?
       headers
     end
 
@@ -81,7 +81,7 @@ module Vra
     end
 
     def authorized?
-      return false if @bearer_token.nil?
+      return false if @bearer_token.value.nil?
 
       response = http_head("/identity/api/tokens/#{@bearer_token.value}", :skip_auth)
       if response.code == 204
@@ -192,7 +192,7 @@ module Vra
     end
 
     def validate_client_options!
-      raise ArgumentError, 'Username and password are required' if @username.nil? || @password.nil?
+      raise ArgumentError, 'Username and password are required' if @username.nil? || @password.value.nil?
       raise ArgumentError, 'A tenant is required' if @tenant.nil?
       raise ArgumentError, 'A base URL is required' if @base_url.nil?
       raise ArgumentError, "Base URL #{@base_url} is not a valid URI." unless valid_uri?(@base_url)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -46,7 +46,7 @@ describe Vra::Client do
   describe '#request_headers' do
     context 'when bearer token exists' do
       it 'has an Authorization header' do
-        client.bearer_token = '12345'
+        client.bearer_token.value = '12345'
         expect(client.request_headers.key?('Authorization')).to be true
       end
     end
@@ -101,7 +101,7 @@ describe Vra::Client do
 
     context 'when token exists' do
       before(:each) do
-        client.bearer_token = '12345'
+        client.bearer_token.value = '12345'
       end
 
       url = '/identity/api/tokens/12345'
@@ -153,7 +153,7 @@ describe Vra::Client do
 
         client.generate_bearer_token
 
-        expect(client.bearer_token).to eq '12345'
+        expect(client.bearer_token.value).to eq '12345'
       end
     end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -37,6 +37,12 @@ describe Vra::Client do
     end
   end
 
+  describe '#bearer_token_request_body' do
+    it 'gets the correct password from the PasswordMasker object' do
+      expect(client.bearer_token_request_body['password']).to eq('password')
+    end
+  end
+
   describe '#request_headers' do
     context 'when bearer token exists' do
       it 'has an Authorization header' do

--- a/vmware-vra.gemspec
+++ b/vmware-vra.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rest-client',    '~> 1.8'
   spec.add_dependency 'ffi-yajl',       '~> 2.2'
-  spec.add_dependency 'passwordmasker', '~> 1.1'
+  spec.add_dependency 'passwordmasker', '~> 1.2'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake',    '~> 10.0'

--- a/vmware-vra.gemspec
+++ b/vmware-vra.gemspec
@@ -18,8 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rest-client', '~> 1.8'
-  spec.add_dependency 'ffi-yajl',    '~> 2.2'
+  spec.add_dependency 'rest-client',    '~> 1.8'
+  spec.add_dependency 'ffi-yajl',       '~> 2.2'
+  spec.add_dependency 'passwordmasker', '~> 1.1'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake',    '~> 10.0'


### PR DESCRIPTION
As a result of PR #7, approaching the masking of passwords in a
more re-usable way so more projects can consume it.  This change
uses the new 'passwordmasker' gem to store the password in an
object that by default returns a masking of '********' vs. the
actual password.