### PR TITLE
Allow setting of pagination page size, raise exception on duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,20 @@ vra.resources.all_resources
 vra.requests.all_requests
 ```
 
+### Pagination
+
+vRA paginates API requests where lists of items are returned.  By default, this gem will ask vRA to provide items in groups of 20.  However, as reported in [Issue 10](https://github.com/chef-partners/vmware-vra-gem/issues/10), it appears vRA may have a pagination bug.  You can change the default page size from 20 to a value of your choice by passing in a `page_size` option when setting up the client:
+
+```ruby
+vra = Vra::Client.new(username: 'devmgr@corp.local', password: 'mypassword', tenant: 'mytenant', base_url: 'https://vra.corp.local', verify_ssl: true, page_size: 100)
+```
+
+... or setting `page_size` on the client object after you've created it:
+
+```ruby
+client.page_size = 100
+```
+
 ## License and Authors
 
 Author:: Chef Partner Engineering (<partnereng@chef.io>)

--- a/lib/vra/client.rb
+++ b/lib/vra/client.rb
@@ -152,7 +152,7 @@ module Vra
         page += 1
       end
 
-      items
+      items.uniq
     end
 
     def http_post(path, payload, skip_auth=nil)

--- a/lib/vra/client.rb
+++ b/lib/vra/client.rb
@@ -23,7 +23,7 @@ require 'passwordmasker'
 module Vra
   # rubocop:disable ClassLength
   class Client
-    attr_accessor :bearer_token
+    attr_accessor :bearer_token, :page_size
 
     def initialize(opts)
       @base_url     = opts[:base_url]
@@ -32,6 +32,7 @@ module Vra
       @tenant       = opts[:tenant]
       @verify_ssl   = opts.fetch(:verify_ssl, true)
       @bearer_token = PasswordMasker.new(nil)
+      @page_size    = opts.fetch(:page_size, 20)
 
       validate_client_options!
     end
@@ -138,10 +139,10 @@ module Vra
       response.body
     end
 
-    def http_get_paginated_array!(path, limit=20)
+    def http_get_paginated_array!(path)
       items = []
       page = 1
-      base_path = path + "?limit=#{limit}"
+      base_path = path + "?limit=#{page_size}"
 
       loop do
         response = FFI_Yajl::Parser.parse(http_get!("#{base_path}&page=#{page}"))

--- a/lib/vra/client.rb
+++ b/lib/vra/client.rb
@@ -152,7 +152,13 @@ module Vra
         page += 1
       end
 
-      items.uniq
+      raise Vra::Exception::DuplicateItemsDetected,
+            'Duplicate items were returned by the vRA API. ' \
+            'Increase your page size to avoid this vRA API bug. ' \
+            'See https://github.com/chef-partners/vmware-vra-gem#pagination ' \
+            'for more information.' if items.uniq!
+
+      items
     end
 
     def http_post(path, payload, skip_auth=nil)

--- a/lib/vra/exceptions.rb
+++ b/lib/vra/exceptions.rb
@@ -20,6 +20,7 @@ require 'ffi_yajl'
 
 module Vra
   module Exception
+    class DuplicateItemsDetected < RuntimeError; end
     class NotFound < RuntimeError; end
     class RequestError < RuntimeError; end
     class Unauthorized < RuntimeError; end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -314,6 +314,14 @@ describe Vra::Client do
 
       client.http_get_paginated_array!('/test')
     end
+
+    it 'raises an exception if duplicate items are returned by the API' do
+      allow(client).to receive(:http_get!)
+        .with('/test?limit=20&page=1')
+        .and_return({ 'content' => [ 1, 2, 3, 1 ], 'metadata' => { 'totalPages' => 1 } }.to_json)
+
+      expect { client.http_get_paginated_array!('/test') }.to raise_error(Vra::Exception::DuplicateItemsDetected)
+    end
   end
 
   describe '#http_post' do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -275,11 +275,12 @@ describe Vra::Client do
 
   describe '#http_get_paginated_array!' do
     it 'allows a limit override' do
+      client.page_size = 10
       expect(client).to receive(:http_get!)
         .with('/test?limit=10&page=1')
         .and_return({ 'content' => [], 'metadata' => { 'totalPages' => 1 } }.to_json)
 
-      client.http_get_paginated_array!('/test', 10)
+      client.http_get_paginated_array!('/test')
     end
 
     it 'only calls http_get! once when total pages is 0 (no items)' do


### PR DESCRIPTION
Issue #10 details a bug in the vRA API dealing with pagination and duplicate results.  This deduplicates the return (which shouldn't be needed, but we can at least try to make our users' lives easier) and allow the user to override the default page size of 20 which is a workaround for the bug.