### PR TITLE
Add accessors for bearer_token

### DIFF
--- a/lib/vra/client.rb
+++ b/lib/vra/client.rb
@@ -23,7 +23,7 @@ require 'passwordmasker'
 module Vra
   # rubocop:disable ClassLength
   class Client
-    attr_accessor :bearer_token, :page_size
+    attr_accessor :page_size
 
     def initialize(opts)
       @base_url     = opts[:base_url]
@@ -58,6 +58,14 @@ module Vra
     #
     # client methods
     #
+
+    def bearer_token
+      @bearer_token.value
+    end
+
+    def bearer_token=(value)
+      @bearer_token.value = value
+    end
 
     def bearer_token_request_body
       {

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -46,7 +46,7 @@ describe Vra::Client do
   describe '#request_headers' do
     context 'when bearer token exists' do
       it 'has an Authorization header' do
-        client.bearer_token.value = '12345'
+        client.bearer_token = '12345'
         expect(client.request_headers.key?('Authorization')).to be true
       end
     end
@@ -101,7 +101,7 @@ describe Vra::Client do
 
     context 'when token exists' do
       before(:each) do
-        client.bearer_token.value = '12345'
+        client.bearer_token = '12345'
       end
 
       url = '/identity/api/tokens/12345'
@@ -153,7 +153,7 @@ describe Vra::Client do
 
         client.generate_bearer_token
 
-        expect(client.bearer_token.value).to eq '12345'
+        expect(client.bearer_token).to eq '12345'
       end
     end
 


### PR DESCRIPTION
When we switched bearer_token to use PasswordMasker, we did not
remove the original attr_accessor for it, and leaving it in allows
for someone to step on the PasswordMasker object and causing bugs.

This addresses the issue raised in #12.