### PR TITLE
Add support for Infrastructure.Cloud resources

### DIFF
--- a/lib/vra/resource.rb
+++ b/lib/vra/resource.rb
@@ -64,7 +64,7 @@ module Vra
     end
 
     def vm?
-      resource_data['resourceTypeRef']['id'] == 'Infrastructure.Virtual'
+      %w(Infrastructure.Virtual Infrastructure.Cloud).include?(resource_data['resourceTypeRef']['id'])
     end
 
     def tenant_id

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -123,8 +123,28 @@ describe Vra::Resource do
     end
 
     describe '#vm?' do
-      it 'returns true for the VM resource we created' do
-        expect(resource.vm?).to be true
+      context 'when the resource type is Infrastructure.Virtual' do
+        let(:resource_data) { { 'resourceTypeRef' => { 'id' => 'Infrastructure.Virtual' } } }
+        it 'returns true' do
+          allow(resource).to receive(:resource_data).and_return(resource_data)
+          expect(resource.vm?).to eq(true)
+        end
+      end
+
+      context 'when the resource type is Infrastructure.Cloud' do
+        let(:resource_data) { { 'resourceTypeRef' => { 'id' => 'Infrastructure.Cloud' } } }
+        it 'returns true' do
+          allow(resource).to receive(:resource_data).and_return(resource_data)
+          expect(resource.vm?).to eq(true)
+        end
+      end
+
+      context 'when the resource type is an unknown type' do
+        let(:resource_data) { { 'resourceTypeRef' => { 'id' => 'Infrastructure.Unknown' } } }
+        it 'returns false' do
+          allow(resource).to receive(:resource_data).and_return(resource_data)
+          expect(resource.vm?).to eq(false)
+        end
       end
     end
 


### PR DESCRIPTION
As reported in kitchen-vra issue #5, the client gem assumes the
only VMs that can be created are Infrastructure.Virtual resources.
This change will support those users using vRA to create EC2
instances.