### PR TITLE
Remove rest-client dependency

### DIFF
--- a/lib/vra/catalog_item.rb
+++ b/lib/vra/catalog_item.rb
@@ -42,7 +42,7 @@ module Vra
     end
 
     def fetch_catalog_item
-      @catalog_item_data = FFI_Yajl::Parser.parse(client.http_get!("/catalog-service/api/consumer/catalogItems/#{id}"))
+      @catalog_item_data = client.get_parsed("/catalog-service/api/consumer/catalogItems/#{id}")
     rescue Vra::Exception::HTTPNotFound
       raise Vra::Exception::NotFound, "catalog ID #{id} does not exist"
     end

--- a/lib/vra/catalog_request.rb
+++ b/lib/vra/catalog_request.rb
@@ -105,7 +105,7 @@ module Vra
         raise
       end
 
-      request_id = response.headers[:location].split('/')[-1]
+      request_id = response.location.split('/')[-1]
       Vra::Request.new(client, request_id)
     end
   end

--- a/lib/vra/http.rb
+++ b/lib/vra/http.rb
@@ -1,0 +1,142 @@
+require 'net/http'
+
+module Vra
+  module Http
+    def self.execute(params)
+      request = Request.new(params)
+      response = request.call
+      response = response.forward(request).call until response.final?
+      fail error(response) unless response.success?
+      response
+    end
+
+    def self.error(response)
+      Error.from_response(response)
+    end
+
+    class Request
+      attr_reader :params
+
+      def initialize(params)
+        @params = params
+      end
+
+      def redirectable?
+        [:get, :head].include?(params[:method])
+      end
+
+      def redirect_to(location)
+        new(url: location)
+      end
+
+      def see_other(location)
+        redirect_to(location).new(method: :get)
+      end
+
+      def call
+        uri = URI(params[:url]) || fail(':url required')
+
+        Net::HTTP.start(uri.host, uri.port,
+                        use_ssl: uri.scheme == 'https') do |http|
+          request = http_request(params[:method], uri)
+          request.initialize_http_header(params[:headers] || {})
+          request.body = params[:payload] || ''
+
+          Response.new(http.request(request))
+        end
+      end
+
+      def http_request(method, uri)
+        type = {
+          get: Net::HTTP::Get,
+          head: Net::HTTP::Head,
+          post: Net::HTTP::Post
+        }.fetch(method, nil)
+
+        fail "Unknown HTTP method #{method}!" unless type
+
+        type.new(uri)
+      end
+
+      protected
+
+      def new(new_params)
+        self.class.new(params.dup.merge(new_params))
+      end
+    end
+
+    class Response
+      # For hiding the details of the HTTP response class
+      # so it can be swapped out easily
+      def initialize(response)
+        @response = response
+      end
+
+      def forward(request)
+        if redirect?
+          fail Http.error(self) unless request.redirectable?
+          request.redirect_to(location)
+        elsif see_other?
+          request.see_other(location)
+        else
+          request
+        end
+      end
+
+      def location
+        @response['location']
+      end
+
+      def body
+        @response.body
+      end
+
+      def code
+        @response.code.to_i
+      end
+
+      def message
+        @response.message
+      end
+
+      def success_ok?
+        code == 200
+      end
+
+      def success_no_content?
+        code == 204
+      end
+
+      def success?
+        (200..207).cover?(code)
+      end
+
+      def redirect?
+        [301, 302, 307].include?(code)
+      end
+
+      def see_other?
+        code == 303
+      end
+
+      def final?
+        !(redirect? || see_other?)
+      end
+    end
+
+    class Error < StandardError
+      def self.from_response(http_response)
+        new(http_response.message, http_response.code, http_response.body)
+      end
+
+      attr_reader :http_code
+      attr_reader :response
+
+      def initialize(message, http_code, response)
+        super(message)
+        @http_code = http_code
+        @response = response
+      end
+    end
+  end
+end

--- a/lib/vra/request.rb
+++ b/lib/vra/request.rb
@@ -32,7 +32,7 @@ module Vra
     end
 
     def refresh
-      @request_data = FFI_Yajl::Parser.parse(client.http_get!("/catalog-service/api/consumer/requests/#{@id}"))
+      @request_data = client.get_parsed("/catalog-service/api/consumer/requests/#{@id}")
     rescue Vra::Exception::HTTPNotFound
       raise Vra::Exception::NotFound, "request ID #{@id} is not found"
     end

--- a/lib/vra/resource.rb
+++ b/lib/vra/resource.rb
@@ -45,7 +45,7 @@ module Vra
     end
 
     def fetch_resource_data
-      @resource_data = FFI_Yajl::Parser.parse(client.http_get!("/catalog-service/api/consumer/resources/#{@id}"))
+      @resource_data = client.get_parsed("/catalog-service/api/consumer/resources/#{@id}")
     rescue Vra::Exception::HTTPNotFound
       raise Vra::Exception::NotFound, "resource ID #{@id} does not exist"
     end
@@ -239,7 +239,7 @@ module Vra
     def submit_action_request(action_id)
       payload = action_request_payload(action_id).to_json
       response = client.http_post('/catalog-service/api/consumer/requests', payload)
-      request_id = response.headers[:location].split('/')[-1]
+      request_id = response.location.split('/')[-1]
       Vra::Request.new(client, request_id)
     end
   end

--- a/spec/catalog_request_spec.rb
+++ b/spec/catalog_request_spec.rb
@@ -106,7 +106,7 @@ describe Vra::CatalogRequest do
     describe '#submit' do
       before do
         allow(request).to receive(:request_payload).and_return({})
-        response = double('response', code: 200, headers: { location: '/requests/request-12345' })
+        response = double('response', location: '/requests/request-12345')
         allow(client).to receive(:http_post).with('/catalog-service/api/consumer/requests', '{}').and_return(response)
       end
 

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -1,0 +1,146 @@
+require 'spec_helper'
+require 'webmock'
+
+describe Vra::Http do
+  def expecting_request(method, url, with=nil)
+    stub = stub_request(method, url)
+    stub.with(with) if with
+    yield if block_given?
+    expect(stub).to have_been_requested
+  end
+
+  def execute(method, params)
+    Vra::Http.execute(params.merge(method: method))
+  end
+
+  def get(params)
+    execute :get, params
+  end
+
+  def post(params)
+    execute :post, params
+  end
+
+  def head(params)
+    execute :head, params
+  end
+
+  describe '#execute' do
+    it 'makes a HEAD request' do
+      headers = { 'X-Made-Up-Header' => 'Foo AND bar?  Are you sure?' }
+
+      expecting_request(:head, 'http://test.local', headers: headers) do
+        head url: 'http://test.local', headers: headers
+      end
+    end
+
+    it 'makes a GET request' do
+      headers = { 'X-Made-Up-Header' => 'Foo AND bar?  Are you sure?' }
+
+      expecting_request(:get, 'http://test.local', headers: headers) do
+        get url: 'http://test.local', headers: headers
+      end
+    end
+
+    it 'makes a POST request' do
+      headers = { 'X-Made-Up-Header' => 'Foo AND bar?  Are you sure?' }
+      payload = 'withabodylikethis'
+
+      expecting_request(:post, 'http://test.local', headers: headers, body: payload) do
+        post url: 'http://test.local', headers: headers, payload: payload
+      end
+    end
+
+    it 'preserves Location' do
+      stub_request(:head, 'http://test.local')
+        .to_return(headers: { 'Location' => 'http://test-location.local' })
+
+      response = head(url: 'http://test.local')
+
+      expect(response.location).to eq 'http://test-location.local'
+    end
+
+    it 'preserves status code' do
+      stub_request(:head, 'http://test.local')
+        .to_return(status: [204, 'No content'])
+
+      response = head(url: 'http://test.local')
+
+      expect(response.code).to eq 204
+    end
+
+    context 'when successful' do
+      it 'returns a successful response given a status 200' do
+        stub_request(:head, 'http://test.local')
+          .to_return(status: [200, 'Whatevs'])
+
+        response = head(url: 'http://test.local')
+
+        expect(response.success_ok?).to be_truthy
+      end
+
+      it 'returns a successful response given a status 204' do
+        stub_request(:head, 'http://test.local')
+          .to_return(status: [204, 'Whatevs'])
+
+        response = head(url: 'http://test.local')
+
+        expect(response.success_no_content?).to be_truthy
+      end
+    end
+
+    context 'when unsuccessful' do
+      (400..418).each do |status|
+        it 'raises an exception given a status #{status}' do
+          stub_request(:get, 'http://test.local')
+            .to_return(status: [status, 'Whatevs'],
+                       body: 'Error body')
+
+          expect { get(url: 'http://test.local') }.to raise_error do |error|
+            expect(error).to be_a(StandardError)
+            expect(error.http_code).to eq status
+            expect(error.response).to eq 'Error body'
+          end
+        end
+      end
+    end
+
+    context 'when redirected' do
+      [301, 302, 307].each do |status|
+        [:get, :head].each do |method|
+          it "follows #{status} redirected #{method.to_s.upcase} requests" do
+            stub_request(method, 'http://test.local')
+              .to_return(status: [status, 'redirect'],
+                         headers: { 'Location' => 'http://test.local/redirect' })
+            expecting_request(method, 'http://test.local/redirect') do
+              execute(method, url: 'http://test.local')
+            end
+          end
+        end
+
+        it "does not follow #{status} redirected POST requests" do
+          stub_request(:post, 'http://test.local')
+            .to_return(status: [status, 'redirect'],
+                       headers: { 'Location' => 'http://test.local/redirect' })
+
+          expect { post(url: 'http://test.local') }.to raise_error do |error|
+            expect(error).to be_a(StandardError)
+            expect(error.http_code).to eq status
+          end
+        end
+      end
+
+      [:head, :post].each do |method|
+        it "converts #{method.to_s.upcase} to GET on 303 redirect" do
+          stub_request(method, 'http://test.local')
+            .to_return(status: [303, 'See Other'],
+                       headers: { 'Location' => 'http://test.local/redirect' })
+
+          expecting_request(:get, 'http://test.local/redirect') do
+            execute method, url: 'http://test.local'
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -71,9 +71,9 @@ describe Vra::Request do
 
   describe '#refresh' do
     it 'calls the request API endpoint' do
-      expect(client).to receive(:http_get!)
+      expect(client).to receive(:get_parsed)
         .with("/catalog-service/api/consumer/requests/#{request_id}")
-        .and_return(in_progress_payload.to_json)
+        .and_return(in_progress_payload)
 
       request.refresh
     end

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -92,10 +92,10 @@ describe Vra::Resource do
   end
 
   describe '#fetch_resource_data' do
-    it 'calls http_get! against the resources API endpoint' do
-      expect(client).to receive(:http_get!)
+    it 'calls get_parsed against the resources API endpoint' do
+      expect(client).to receive(:get_parsed)
         .with("/catalog-service/api/consumer/resources/#{resource_id}")
-        .and_return('')
+        .and_return({})
 
       Vra::Resource.new(client, id: resource_id)
     end
@@ -356,7 +356,7 @@ describe Vra::Resource do
     describe '#submit_action_request' do
       before do
         allow(resource).to receive(:action_request_payload).and_return({})
-        response = double('response', code: 200, headers: { location: '/requests/request-12345' })
+        response = double('response', location: '/requests/request-12345')
         allow(client).to receive(:http_post).with('/catalog-service/api/consumer/requests', '{}').and_return(response)
       end
 

--- a/vmware-vra.gemspec
+++ b/vmware-vra.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rest-client',    '~> 1.8'
   spec.add_dependency 'ffi-yajl',       '~> 2.2'
   spec.add_dependency 'passwordmasker', '~> 1.2'
 


### PR DESCRIPTION
This patch removes the dependency on the rest-client gem.

This has mostly been achieved by replacing RestClient-specific API calls with a
small `Net::HTTP` wrapper in `lib/vra/http.rb`.  A reasonable attempt has been made
to retain RestClient's HTTP request lifecycle behaviour and exception raising,
to minimise the impact of the change.

Some refactoring has also been done to the users of `Vra::Client`, to simplify the
removal slightly.