### PR TITLE
instructing Net::HTTP not to verify SSL when verify_ssl is false

### DIFF
--- a/lib/vra/http.rb
+++ b/lib/vra/http.rb
@@ -36,8 +36,10 @@ module Vra
       def call
         uri = URI(params[:url]) || fail(':url required')
 
-        Net::HTTP.start(uri.host, uri.port,
-                        use_ssl: uri.scheme == 'https') do |http|
+        ssl_params = { use_ssl: uri.scheme == 'https' }
+        ssl_params[:verify_mode] = OpenSSL::SSL::VERIFY_NONE unless verify_ssl?
+
+        Net::HTTP.start(uri.host, uri.port, ssl_params) do |http|
           request = http_request(params[:method], uri)
           request.initialize_http_header(params[:headers] || {})
           request.body = params[:payload] || ''
@@ -62,6 +64,11 @@ module Vra
 
       def new(new_params)
         self.class.new(params.dup.merge(new_params))
+      end
+
+      def verify_ssl?
+        return true if params[:verify_ssl].nil?
+        params[:verify_ssl]
       end
     end
 

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -69,6 +69,15 @@ describe Vra::Http do
       expect(response.code).to eq 204
     end
 
+    it 'configures ssl verification' do
+      allow(Net::HTTP).to receive(:start).and_wrap_original do |_http, *args|
+        expect(args.last).to include(verify_mode: OpenSSL::SSL::VERIFY_NONE)
+        double('response', final?: true, success?: true)
+      end
+
+      execute(:get, url: 'https://test.local', verify_ssl: false)
+    end
+
     context 'when successful' do
       it 'returns a successful response given a status 200' do
         stub_request(:head, 'http://test.local')


### PR DESCRIPTION
addresses #30, tests included.