### PR TITLE
vra 7.0.1 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-- 2.0.0
-- 2.1
-- 2.2
+- 2.2.2
+- 2.3.1
 branches:
   only:
   - master

--- a/lib/vra/catalog_request.rb
+++ b/lib/vra/catalog_request.rb
@@ -82,7 +82,7 @@ module Vra
             Vra::RequestParameter.new('provider-VirtualMachine.CPU.Count', 'integer', @cpus).to_h,
             Vra::RequestParameter.new('provider-VirtualMachine.Memory.Size', 'integer', @memory).to_h,
             Vra::RequestParameter.new('provider-VirtualMachine.LeaseDays', 'integer', @lease_days).to_h,
-            Vra::RequestParameter.new('provider-__Notes', 'string', @notes).to_h
+            Vra::RequestParameter.new('description', 'string', @notes).to_h
           ]
         }
       }


### PR DESCRIPTION
Issue #33 

This will write to the `description` field instead of the `__Notes` field.  It may possibly break compatibility with VRA 6.x.  I don't have an install of the older VRA to test against.  

If @jjasghar we can figure out a way to make this work on both VRA 6.x and 7.x that would be ideal.

The other thing that would be nice with this would be to write to not only the `description` field (which will tag the value as the description of the request and the deployment) but also to write to the description field of the machine.  Not sure how to do that though.  Spent most of the morning trying different combinations of parameters that seemed likely fits, but none of them got me anywhere.
