### PR TITLE
Updates extra_params to check for top level props

### DIFF
--- a/lib/vra/catalog_request.rb
+++ b/lib/vra/catalog_request.rb
@@ -73,7 +73,11 @@ module Vra
       hash_payload["description"] = @notes
 
       parameters.each do |param|
-        hash_payload["data"][blueprint_name]["data"][param.key] = param.value
+        if hash_payload['data'].key? param.key
+          hash_payload['data'][param.key] = param.value
+        else
+          hash_payload["data"][blueprint_name]["data"][param.key] = param.value
+        end
       end
 
       JSON.pretty_generate(hash_payload)

--- a/lib/vra/version.rb
+++ b/lib/vra/version.rb
@@ -18,5 +18,5 @@
 #
 
 module Vra
-  VERSION = "2.1.1"
+  VERSION = "2.1.2"
 end


### PR DESCRIPTION
The vRA API will throw an error if you pass custom properties that are
defined at the top level of the blueprint (['data']) in a lower level
(ie ['data']['blueprint_name']).  This change checks the top level for
an attribute, and populates it there if it exists.

Signed-off-by: Nolan Davidson <ndavidson@chef.io>