### PR TITLE
Fixing missing messages from some HTTP exceptions

### DIFF
--- a/lib/vra/catalog_request.rb
+++ b/lib/vra/catalog_request.rb
@@ -73,8 +73,8 @@ module Vra
       hash_payload["description"] = @notes
 
       parameters.each do |param|
-        if hash_payload['data'].key? param.key
-          hash_payload['data'][param.key] = param.value
+        if hash_payload["data"].key? param.key
+          hash_payload["data"][param.key] = param.value
         else
           hash_payload["data"][blueprint_name]["data"][param.key] = param.value
         end

--- a/lib/vra/client.rb
+++ b/lib/vra/client.rb
@@ -22,7 +22,6 @@ require "passwordmasker"
 require "vra/http"
 
 module Vra
-  # rubocop:disable ClassLength
   class Client
     attr_accessor :page_size
 

--- a/lib/vra/exceptions.rb
+++ b/lib/vra/exceptions.rb
@@ -49,7 +49,11 @@ module Vra
         return unless data["errors"].respond_to?(:each)
 
         data["errors"].each do |error|
-          @errors << error["systemMessage"]
+          if error["systemMessage"]
+            @errors << error["systemMessage"]
+          else
+            @errors << error["message"]
+          end
         end
       end
     end

--- a/lib/vra/resource.rb
+++ b/lib/vra/resource.rb
@@ -20,7 +20,6 @@
 require "ffi_yajl"
 
 module Vra
-  # rubocop:disable ClassLength
   class Resource
     attr_reader :client, :id, :resource_data
 
@@ -157,7 +156,7 @@ module Vra
       end
     end
 
-    def ip_addresses # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    def ip_addresses
       return if !vm? || network_interfaces.nil?
 
       addrs = []

--- a/lib/vra/version.rb
+++ b/lib/vra/version.rb
@@ -18,5 +18,5 @@
 #
 
 module Vra
-  VERSION = "2.1.2"
+  VERSION = "2.1.3"
 end


### PR DESCRIPTION
Some error responses aren't displaying error messages.  For example,
submitting a request with a requested_for value of a username not in
email form (ie, admin instead of admin@myvsphere.local) would return an
error, but not display its output.  It turns out that this error (and
others, I imagine) doesn't contain a systemMessage field.  This change
checks for a systemMessage first, but if one doesn't exist it will use
the message field instead. Not sure if this will cover all possible
error cases, but it at least covers more than we do now.

Also cleaned up rubocop offenses.

Signed-off-by: Nolan Davidson <ndavidson@chef.io>