### PR TITLE
Fixes #45 - usage of openssl raises error

### DIFF
--- a/lib/vra/http.rb
+++ b/lib/vra/http.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "net/http"
+require "openssl"
 
 module Vra
   module Http


### PR DESCRIPTION
   * previously the http.rb file used the OPENSSL library
     without loading the openssl library.  Without this fix
     an error is raised unless you load openssl manually outside/before
     using the vmware_vra gem.