### PR TITLE
Symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ catalog_request.set_parameter('object~my_parameter', 'string', 'my value')
 ```
 
 ### Creating a request from a yaml or json payload
-Should you want to create a request ahead of time you can create the parameters up front by 
+Should you want to create a request ahead of time you can create the parameters up front by
 reading from a file or a hard coded payload you use every time.  This is not required by any means but allows
-for some extra flexibility when using this request object directly.  The only difference is that you can pass 
+for some extra flexibility when using this request object directly.  The only difference is that you can pass
 in the request parameters instead of having to set them after you create the object.
 
 Given a sample request object like the following you will want to read the yaml into an ruby object:
@@ -131,18 +131,18 @@ And now use that data to create the Vra::RequestParameters to feed into the cata
 ```ruby
 # read in the request data
 yaml_data = YAML,load(data)
-# create a parameters array
+# create a parameters array, although this only works with VRA6, since VRA7 can have complex data
 parameters = yaml_data['requestData']['entries'].map {|item| [item['key'], item['value'].values].flatten }
 # We put the values in a array so we can easily explode the parameters using the splat operator later
-request_parans = Vra::RequestParameters.new
-# loop through each parameter and setting each parameter 
+request_params = Vra::RequestParameters.new
+# loop through each parameter and setting each parameter
 parameters.each {|p| request_params.set(*p)  # splat
 request_options = {
   cpus: 1,
   memory: 1024,
   requested_for: 'me@me.com',
   lease_days: 2,
-  additional_params: request_parans
+  additional_params: request_params
 }
 # create the request
 catalog_request = vra.catalog.request(blueprint, request_options)

--- a/lib/vra/request_parameters.rb
+++ b/lib/vra/request_parameters.rb
@@ -22,12 +22,18 @@ module Vra
       @entries = {}
     end
 
+    # @param key [String] - the name of the key
+    # @param value_data [Hash] - the data of the key name
+    # @note - the value_data must have type and value property in the hash
     def set_parameters(key, value_data, parent = nil)
-      if value_data.key?(:type)
+      value_type = value_data[:type] || value_data["type"]
+      data_value = value_data[:value] || value_data["value"]
+
+      if value_type
         if parent.nil?
-          set(key, value_data[:type], value_data[:value])
+          set(key, value_type, data_value)
         else
-          parent.add_child(Vra::RequestParameter.new(key, value_data[:type], value_data[:value]))
+          parent.add_child(Vra::RequestParameter.new(key, value_type, data_value))
         end
       else
         if parent.nil?

--- a/lib/vra/version.rb
+++ b/lib/vra/version.rb
@@ -18,5 +18,5 @@
 #
 
 module Vra
-  VERSION = "2.3.0".freeze
+  VERSION = "2.3.0"
 end


### PR DESCRIPTION
### Description

Aside from the typo fix.  This PR allows one to pass in value_data to set_parameters without requiring symbols to be the key names.  This is important because when we read from serialized data (JSON) we can't assume the serialized content contains symbols (which JSON does not).  

### Issues Resolved

#51 - Typo in REadme
### Check List

- [x] All tests pass.
- [x] All style checks pass.
- [x] Functionality includes testing.
- [x] Functionality has been documented in the README if applicable
