### PR TITLE
Adds the ability to dump catalog templates via class methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,19 @@ vra.resources.all_resources
 vra.requests.all_requests
 ```
 
+### Download VRA catalog templates
+It can be quite useful to download the catalog templates from your VRA server for future playback or inspection.  This
+can now be easily done with some helpful class methods.
+
+To get a json string representation of the catalog template you can use `Vra::CatalogItem.dump_template(client, catalog_id)`
+
+To dump the catalog template to a file instead of a string `Vra::CatalogItem.write_template(client, catalog_id)`.  This will create a file like `windows2012.json`.
+
+If you just want to dump all the templates you can use `Vra::CatalogItem.dump_templates(client)`.  This will create a directory named vra_templates
+with all the entitled templates for the current user.  
+
+There are additional options you can provide to these methods in order to customize output file names and directories, so please see the source code in lib/vra/catalog_item.rb
+
 ### Pagination
 
 vRA paginates API requests where lists of items are returned.  By default, this gem will ask vRA to provide items in groups of 20.  However, as reported in [Issue 10](https://github.com/chef-partners/vmware-vra-gem/issues/10), it appears vRA may have a pagination bug.  You can change the default page size from 20 to a value of your choice by passing in a `page_size` option when setting up the client:

--- a/lib/vra/catalog_item.rb
+++ b/lib/vra/catalog_item.rb
@@ -18,6 +18,7 @@
 #
 
 require "ffi_yajl"
+require "vra/catalog"
 
 module Vra
   class CatalogItem
@@ -84,6 +85,46 @@ module Vra
 
     def blueprint_id
       @catalog_item_data["providerBinding"]["bindingId"]
+    end
+
+    # @param [String] - the id of the catalog item
+    # @param [Vra::Client] - a vra client object
+    # @return [String] - returns a json string of the catalog template
+    def self.dump_template(client, id)
+      response = client.http_get("/catalog-service/api/consumer/entitledCatalogItems/#{id}/requests/template")
+      response.body
+    end
+
+    # @param client [Vra::Client] - a vra client object
+    # @param id [String] - the id of the catalog item
+    # @param filename [String] - the name of the file you want to output the template to
+    # if left blank, will default to the id of the item
+    # @note outputs the catalog template to a file in serialized format
+    def self.write_template(client, id, filename = nil)
+      filename ||= "#{id}.json"
+      begin
+        contents = dump_template(client, id)
+        data = JSON.parse(contents)
+        pretty_contents = JSON.pretty_generate(data)
+        File.write(filename, pretty_contents)
+        return filename
+      rescue Vra::Exception::HTTPError => e
+        raise e
+      end
+    end
+
+    # @param [Vra::Client] - a vra client object
+    # @param [String] - the directory path to write the files to
+    # @param [Boolean] - set to true if you wish the file name to be the id of the catalog item
+    # @return [Array[String]] - a array of all the files that were generated
+    def self.dump_templates(client, dir_name = "vra_templates", use_id = false)
+      FileUtils.mkdir(dir_name) unless File.exist?(dir_name)
+      client.catalog.entitled_items.map do |c|
+        id = use_id ? c.id : c.name.tr(" ", "_")
+        filename = File.join(dir_name, "#{id}.json").downcase
+        write_template(client, c.id, filename)
+        filename
+      end
     end
   end
 end

--- a/spec/catalog_item_spec.rb
+++ b/spec/catalog_item_spec.rb
@@ -54,6 +54,31 @@ describe Vra::CatalogItem do
     }
   end
 
+  let(:other_catalog_item_payload) do
+    {
+        "@type" => "CatalogItem",
+        "id" => "3232323e-5443-4082-afd5-ab5a32939bbc",
+        "version" => 2,
+        "name" => "CentOS 6.6",
+        "description" => "Blueprint for deploying a CentOS Linux development server",
+        "status" => "PUBLISHED",
+        "statusName" => "Published",
+        "organization" => {
+            "tenantRef" => "vsphere.local",
+            "tenantLabel" => "vsphere.local",
+            "subtenantRef" => "962ab3f9-858c-4483-a49f-fa97392c314b",
+            "subtenantLabel" => "catalog_subtenant",
+        },
+        "providerBinding" => {
+            "bindingId" => "33af5413-4f20-4b3b-8268-32edad434dfb",
+            "providerRef" => {
+                "id" => "c3b2bc30-47b0-454f-b57d-df02a7356fe6",
+                "label" => "iaas-service",
+            },
+        },
+    }
+  end
+
   describe "#initialize" do
     it "raises an error if no ID or catalog item data have been provided" do
       expect { Vra::CatalogItem.new }.to raise_error(ArgumentError)
@@ -135,5 +160,124 @@ describe Vra::CatalogItem do
         expect(catalog_item.organization["tenantRef"]).to eq(nil)
       end
     end
+
+    describe "class methods" do
+      let(:response) { double("response", code: 200, body: catalog_item_payload.to_json) }
+
+      it "#dump_template" do
+        expect(client).to receive(:http_get).with("/catalog-service/api/consumer/entitledCatalogItems/#{catalog_id}/requests/template")
+                              .and_return(response)
+        described_class.dump_template(client, catalog_id )
+      end
+
+      it "#write_template" do
+        allow(client).to receive(:http_get).with("/catalog-service/api/consumer/entitledCatalogItems/#{catalog_id}/requests/template")
+                             .and_return(response)
+        expect(File).to receive(:write).with("9e98042e-5443-4082-afd5-ab5a32939bbc.json", JSON.pretty_generate(catalog_item_payload))
+        expect(described_class.write_template(client, catalog_id)).to eq("9e98042e-5443-4082-afd5-ab5a32939bbc.json")
+      end
+
+      it "#write_template with custom filename" do
+        allow(client).to receive(:http_get).with("/catalog-service/api/consumer/entitledCatalogItems/#{catalog_id}/requests/template")
+                             .and_return(response)
+        expect(File).to receive(:write).with("somefile.json", JSON.pretty_generate(catalog_item_payload))
+        expect(described_class.write_template(client, catalog_id, "somefile.json")).to eq("somefile.json")
+      end
+
+      context "entitled items" do
+        let(:response2) { double("response", code: 200, body: other_catalog_item_payload.to_json) }
+
+        let(:entitled_catalog_item) do
+          {
+              "@type" => "ConsumerEntitledCatalogItem",
+              "catalogItem" => {
+                  "id" => "d29efd6b-3cd6-4f8d-b1d8-da4ddd4e52b1",
+                  "version" => 2,
+                  "name" => "WindowsServer2012",
+                  "description" => "Windows Server 2012 with the latest updates and patches.",
+                  "status" => "PUBLISHED",
+                  "statusName" => "Published",
+                  "organization" => {
+                      "tenantRef" => "vsphere.local",
+                      "tenantLabel" => "vsphere.local",
+                      "subtenantRef" => nil,
+                      "subtenantLabel" => nil,
+                  },
+                  "providerBinding" => {
+                      "bindingId" => "59fd02a1-acca-4918-9d3d-2298d310caef",
+                      "providerRef" => {
+                          "id" => "c3b2bc30-47b0-454f-b57d-df02a7356fe6",
+                          "label" => "iaas-service",
+                      },
+                  },
+              },
+          }
+        end
+
+        let(:entitled_catalog_item2) do
+          {
+              "@type" => "ConsumerEntitledCatalogItem",
+              "catalogItem" => {
+                  "id" => "3232323e-5443-4082-afd5-ab5a32939bbc",
+                  "version" => 2,
+                  "name" => "WindowsServer2016",
+                  "description" => "Windows Server 2012 with the latest updates and patches.",
+                  "status" => "PUBLISHED",
+                  "statusName" => "Published",
+                  "organization" => {
+                      "tenantRef" => "vsphere.local",
+                      "tenantLabel" => "vsphere.local",
+                      "subtenantRef" => nil,
+                      "subtenantLabel" => nil,
+                  },
+                  "providerBinding" => {
+                      "bindingId" => "59fd02a1-acca-4918-9d3d-2298d310caef",
+                      "providerRef" => {
+                          "id" => "c3b2bc30-47b0-454f-b57d-df02a7356fe6",
+                          "label" => "iaas-service",
+                      },
+                  },
+              },
+          }
+        end
+
+        before(:each) do
+          allow(client).to receive(:http_get_paginated_array!).with("/catalog-service/api/consumer/entitledCatalogItems")
+                                .and_return([ entitled_catalog_item, entitled_catalog_item2 ])
+          allow(client).to receive(:http_get)
+                               .with("/catalog-service/api/consumer/entitledCatalogItems/d29efd6b-3cd6-4f8d-b1d8-da4ddd4e52b1/requests/template")
+                               .and_return(response)
+          allow(client).to receive(:http_get)
+                               .with("/catalog-service/api/consumer/entitledCatalogItems/3232323e-5443-4082-afd5-ab5a32939bbc/requests/template")
+                               .and_return(response)
+          allow(File).to receive(:write).with("vra_templates/d29efd6b-3cd6-4f8d-b1d8-da4ddd4e52b1.json", JSON.pretty_generate(catalog_item_payload))
+          allow(File).to receive(:write).with("vra_templates/3232323e-5443-4082-afd5-ab5a32939bbc.json", JSON.pretty_generate(catalog_item_payload))
+          allow(File).to receive(:write).with("vra_templates/windowsserver2012.json", JSON.pretty_generate(catalog_item_payload))
+          allow(File).to receive(:write).with("vra_templates/windowsserver2016.json", JSON.pretty_generate(catalog_item_payload))
+          allow(File).to receive(:write).with("custom_dir/windowsserver2012.json", JSON.pretty_generate(catalog_item_payload))
+          allow(File).to receive(:write).with("custom_dir/windowsserver2016.json", JSON.pretty_generate(catalog_item_payload))
+
+        end
+
+        it "#dump_templates" do
+          expect(described_class.dump_templates(client)).to eq(["vra_templates/windowsserver2012.json",
+                                                                "vra_templates/windowsserver2016.json"])
+        end
+
+        it "#dump_templates with custom directory" do
+          expect(described_class.dump_templates(client, "custom_dir")).to eq(["custom_dir/windowsserver2012.json",
+                                                                              "custom_dir/windowsserver2016.json"])
+        end
+
+        it "#dump_templates with id" do
+          expect(described_class.dump_templates(client, "vra_templates", true))
+              .to eq(["vra_templates/d29efd6b-3cd6-4f8d-b1d8-da4ddd4e52b1.json",
+                      "vra_templates/3232323e-5443-4082-afd5-ab5a32939bbc.json"])
+
+        end
+      end
+
+    end
+
   end
 end


### PR DESCRIPTION
### Description
This allows us to dump catalog templates to a string or file.  This is helpful
for when the user wants to save the request template for inspection or 
later playback.

### Issues Resolved

N|A

### Check List

- [x] All tests pass.
- [x] All style checks pass.
- [x] Functionality includes testing.
- [x] Functionality has been documented in the README if applicable
