### PR TITLE
Adds ability to supply template files to catalog request

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,19 @@ vra.resources.all_resources
 vra.requests.all_requests
 ```
 
+### Download VRA catalog templates
+It can be quite useful to download the catalog templates from your VRA server for future playback or inspection.  This
+can now be easily done with some helpful class methods.
+
+To get a json string representation of the catalog template you can use `Vra::CatalogItem.dump_template(client, catalog_id)`
+
+To dump the catalog template to a file instead of a string `Vra::CatalogItem.write_template(client, catalog_id)`.  This will create a file like `windows2012.json`.
+
+If you just want to dump all the templates you can use `Vra::CatalogItem.dump_templates(client)`.  This will create a directory named vra_templates
+with all the entitled templates for the current user.  
+
+There are additional options you can provide to these methods in order to customize output file names and directories, so please see the source code in lib/vra/catalog_item.rb
+
 ### Pagination
 
 vRA paginates API requests where lists of items are returned.  By default, this gem will ask vRA to provide items in groups of 20.  However, as reported in [Issue 10](https://github.com/chef-partners/vmware-vra-gem/issues/10), it appears vRA may have a pagination bug.  You can change the default page size from 20 to a value of your choice by passing in a `page_size` option when setting up the client:

--- a/README.md
+++ b/README.md
@@ -243,6 +243,30 @@ with all the entitled templates for the current user.
 
 There are additional options you can provide to these methods in order to customize output file names and directories, so please see the source code in lib/vra/catalog_item.rb
 
+### Supply custom VRA catalog template and create request
+If you previously had some custom templates already in JSON format you can now use those to create requests instead of setting
+a bunch of parameters.  This can be especially useful when your request has complex parameters or you have a bunch of templates
+that you want to create unique requests for.
+
+To use you can do something like:
+
+```ruby
+payload_file = '/tmp/windows_2012.json'  # must be in json format
+cr = Vra::CatalogRequest.request_from_payload(client, payload_file)
+cr.submit
+
+```
+
+If you already have a catalog request object you can still supply a custom payload by simply setting the template_payload property.
+Note this custom payload will be merged with the properties originally set when creating the catalog request object.
+
+```ruby
+cr = Vra::CatalogRequest.new(id, opts)
+cr.template_payload = File.read('/tmp/windows_2012.json')
+cr.submit
+
+```
+
 ### Pagination
 
 vRA paginates API requests where lists of items are returned.  By default, this gem will ask vRA to provide items in groups of 20.  However, as reported in [Issue 10](https://github.com/chef-partners/vmware-vra-gem/issues/10), it appears vRA may have a pagination bug.  You can change the default page size from 20 to a value of your choice by passing in a `page_size` option when setting up the client:

--- a/lib/vra/catalog_item.rb
+++ b/lib/vra/catalog_item.rb
@@ -18,6 +18,7 @@
 #
 
 require "ffi_yajl"
+require "vra/catalog"
 
 module Vra
   class CatalogItem
@@ -84,6 +85,46 @@ module Vra
 
     def blueprint_id
       @catalog_item_data["providerBinding"]["bindingId"]
+    end
+
+    # @param [String] - the id of the catalog item
+    # @param [Vra::Client] - a vra client object
+    # @return [String] - returns a json string of the catalog template
+    def self.dump_template(client, id)
+      response = client.http_get("/catalog-service/api/consumer/entitledCatalogItems/#{id}/requests/template")
+      response.body
+    end
+
+    # @param client [Vra::Client] - a vra client object
+    # @param id [String] - the id of the catalog item
+    # @param filename [String] - the name of the file you want to output the template to
+    # if left blank, will default to the id of the item
+    # @note outputs the catalog template to a file in serialized format
+    def self.write_template(client, id, filename = nil)
+      filename ||= "#{id}.json"
+      begin
+        contents = dump_template(client, id)
+        data = JSON.parse(contents)
+        pretty_contents = JSON.pretty_generate(data)
+        File.write(filename, pretty_contents)
+        return filename
+      rescue Vra::Exception::HTTPError => e
+        raise e
+      end
+    end
+
+    # @param [Vra::Client] - a vra client object
+    # @param [String] - the directory path to write the files to
+    # @param [Boolean] - set to true if you wish the file name to be the id of the catalog item
+    # @return [Array[String]] - a array of all the files that were generated
+    def self.dump_templates(client, dir_name = "vra_templates", use_id = false)
+      FileUtils.mkdir(dir_name) unless File.exist?(dir_name)
+      client.catalog.entitled_items.map do |c|
+        id = use_id ? c.id : c.name.tr(" ", "_")
+        filename = File.join(dir_name, "#{id}.json").downcase
+        write_template(client, c.id, filename)
+        filename
+      end
     end
   end
 end

--- a/lib/vra/catalog_request.rb
+++ b/lib/vra/catalog_request.rb
@@ -16,12 +16,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require "vra/catalog_item"
 
 module Vra
   class CatalogRequest
     attr_reader :catalog_id, :catalog_item, :client, :custom_fields
     attr_writer :subtenant_id
-    attr_accessor :cpus, :memory, :requested_for, :lease_days, :notes
+    attr_accessor :cpus, :memory, :requested_for, :lease_days, :notes, :template_payload
 
     def initialize(client, catalog_id, opts = {})
       @client            = client
@@ -33,8 +34,27 @@ module Vra
       @notes             = opts[:notes]
       @subtenant_id      = opts[:subtenant_id]
       @additional_params = opts[:additional_params] || Vra::RequestParameters.new
-
       @catalog_item = Vra::CatalogItem.new(client, id: catalog_id)
+    end
+
+    # @param payload_file [String] - A json payload that represents the catalog template you want to merge with this request
+    # @param client [Vra::Client] - a vra client object
+    # @return [Vra::CatalogRequest] - a request with the given payload merged
+    def self.request_from_payload(client, payload_file)
+      hash_payload = JSON.parse(File.read(payload_file))
+      catalog_id = hash_payload["catalogItemId"]
+      blueprint_name = hash_payload["data"].select { |_k, v| v.is_a?(Hash) }.keys.first
+      blueprint_data = hash_payload["data"][blueprint_name]
+      opts = {}
+      opts[:cpus] = blueprint_data["data"]["cpu"]
+      opts[:memory] = blueprint_data["data"]["memory"]
+      opts[:requested_for] = hash_payload["requestedFor"]
+      opts[:lease_days] = blueprint_data.fetch("leaseDays", nil) || hash_payload["data"].fetch("_lease_days", 1)
+      opts[:description] = hash_payload["description"]
+      opts[:subtenant_id] = hash_payload["businessGroupId"]
+      cr = Vra::CatalogRequest.new(client, catalog_id, opts)
+      cr.template_payload = File.read(payload_file)
+      cr
     end
 
     def set_parameter(key, type, value)
@@ -66,31 +86,40 @@ module Vra
       raise ArgumentError, "Unable to submit request, required param(s) missing => #{missing_params.join(', ')}" unless missing_params.empty?
     end
 
+    # @return [String] - the current catalog template payload merged with the settings applied from this request
+    # @param [String] - A json payload that represents the catalog template you want to merge with this request
     def merge_payload(payload)
       hash_payload = JSON.parse(payload)
       blueprint_name = hash_payload["data"].select { |_k, v| v.is_a?(Hash) }.keys.first
-
       hash_payload["data"][blueprint_name]["data"]["cpu"] = @cpus
       hash_payload["data"][blueprint_name]["data"]["memory"] = @memory
       hash_payload["requestedFor"] = @requested_for
       hash_payload["data"]["_leaseDays"] = @lease_days
       hash_payload["description"] = @notes
-
       JSON.pretty_generate(deep_merge(hash_payload, parameters))
     end
 
+    # @return [String] - the current catalog template payload merged with the settings applied from this request
+    def merged_payload
+      merge_payload(template_payload)
+    end
+
+    # @return [String] - the current catalog template payload from VRA or custom payload set in JSON format
+    def template_payload
+      @template_payload ||= Vra::CatalogItem.dump_template(client, @catalog_id)
+    end
+
+    # @return [Vra::Request] - submits and returns the request, validating before hand
     def submit
       validate_params!
 
       begin
-        response = client.http_get("/catalog-service/api/consumer/entitledCatalogItems/#{@catalog_id}/requests/template")
-        post_response = client.http_post("/catalog-service/api/consumer/entitledCatalogItems/#{@catalog_id}/requests", merge_payload(response.body))
+        post_response = client.http_post("/catalog-service/api/consumer/entitledCatalogItems/#{@catalog_id}/requests", merged_payload)
       rescue Vra::Exception::HTTPError => e
         raise Vra::Exception::RequestError, "Unable to submit request: #{e.errors.join(', ')}"
       rescue
         raise
       end
-
       request_id = JSON.parse(post_response.body)["id"]
       Vra::Request.new(client, request_id)
     end

--- a/spec/catalog_item_spec.rb
+++ b/spec/catalog_item_spec.rb
@@ -54,6 +54,31 @@ describe Vra::CatalogItem do
     }
   end
 
+  let(:other_catalog_item_payload) do
+    {
+        "@type" => "CatalogItem",
+        "id" => "3232323e-5443-4082-afd5-ab5a32939bbc",
+        "version" => 2,
+        "name" => "CentOS 6.6",
+        "description" => "Blueprint for deploying a CentOS Linux development server",
+        "status" => "PUBLISHED",
+        "statusName" => "Published",
+        "organization" => {
+            "tenantRef" => "vsphere.local",
+            "tenantLabel" => "vsphere.local",
+            "subtenantRef" => "962ab3f9-858c-4483-a49f-fa97392c314b",
+            "subtenantLabel" => "catalog_subtenant",
+        },
+        "providerBinding" => {
+            "bindingId" => "33af5413-4f20-4b3b-8268-32edad434dfb",
+            "providerRef" => {
+                "id" => "c3b2bc30-47b0-454f-b57d-df02a7356fe6",
+                "label" => "iaas-service",
+            },
+        },
+    }
+  end
+
   describe "#initialize" do
     it "raises an error if no ID or catalog item data have been provided" do
       expect { Vra::CatalogItem.new }.to raise_error(ArgumentError)
@@ -135,5 +160,124 @@ describe Vra::CatalogItem do
         expect(catalog_item.organization["tenantRef"]).to eq(nil)
       end
     end
+
+    describe "class methods" do
+      let(:response) { double("response", code: 200, body: catalog_item_payload.to_json) }
+
+      it "#dump_template" do
+        expect(client).to receive(:http_get).with("/catalog-service/api/consumer/entitledCatalogItems/#{catalog_id}/requests/template")
+                              .and_return(response)
+        described_class.dump_template(client, catalog_id )
+      end
+
+      it "#write_template" do
+        allow(client).to receive(:http_get).with("/catalog-service/api/consumer/entitledCatalogItems/#{catalog_id}/requests/template")
+                             .and_return(response)
+        expect(File).to receive(:write).with("9e98042e-5443-4082-afd5-ab5a32939bbc.json", JSON.pretty_generate(catalog_item_payload))
+        expect(described_class.write_template(client, catalog_id)).to eq("9e98042e-5443-4082-afd5-ab5a32939bbc.json")
+      end
+
+      it "#write_template with custom filename" do
+        allow(client).to receive(:http_get).with("/catalog-service/api/consumer/entitledCatalogItems/#{catalog_id}/requests/template")
+                             .and_return(response)
+        expect(File).to receive(:write).with("somefile.json", JSON.pretty_generate(catalog_item_payload))
+        expect(described_class.write_template(client, catalog_id, "somefile.json")).to eq("somefile.json")
+      end
+
+      context "entitled items" do
+        let(:response2) { double("response", code: 200, body: other_catalog_item_payload.to_json) }
+
+        let(:entitled_catalog_item) do
+          {
+              "@type" => "ConsumerEntitledCatalogItem",
+              "catalogItem" => {
+                  "id" => "d29efd6b-3cd6-4f8d-b1d8-da4ddd4e52b1",
+                  "version" => 2,
+                  "name" => "WindowsServer2012",
+                  "description" => "Windows Server 2012 with the latest updates and patches.",
+                  "status" => "PUBLISHED",
+                  "statusName" => "Published",
+                  "organization" => {
+                      "tenantRef" => "vsphere.local",
+                      "tenantLabel" => "vsphere.local",
+                      "subtenantRef" => nil,
+                      "subtenantLabel" => nil,
+                  },
+                  "providerBinding" => {
+                      "bindingId" => "59fd02a1-acca-4918-9d3d-2298d310caef",
+                      "providerRef" => {
+                          "id" => "c3b2bc30-47b0-454f-b57d-df02a7356fe6",
+                          "label" => "iaas-service",
+                      },
+                  },
+              },
+          }
+        end
+
+        let(:entitled_catalog_item2) do
+          {
+              "@type" => "ConsumerEntitledCatalogItem",
+              "catalogItem" => {
+                  "id" => "3232323e-5443-4082-afd5-ab5a32939bbc",
+                  "version" => 2,
+                  "name" => "WindowsServer2016",
+                  "description" => "Windows Server 2012 with the latest updates and patches.",
+                  "status" => "PUBLISHED",
+                  "statusName" => "Published",
+                  "organization" => {
+                      "tenantRef" => "vsphere.local",
+                      "tenantLabel" => "vsphere.local",
+                      "subtenantRef" => nil,
+                      "subtenantLabel" => nil,
+                  },
+                  "providerBinding" => {
+                      "bindingId" => "59fd02a1-acca-4918-9d3d-2298d310caef",
+                      "providerRef" => {
+                          "id" => "c3b2bc30-47b0-454f-b57d-df02a7356fe6",
+                          "label" => "iaas-service",
+                      },
+                  },
+              },
+          }
+        end
+
+        before(:each) do
+          allow(client).to receive(:http_get_paginated_array!).with("/catalog-service/api/consumer/entitledCatalogItems")
+                                .and_return([ entitled_catalog_item, entitled_catalog_item2 ])
+          allow(client).to receive(:http_get)
+                               .with("/catalog-service/api/consumer/entitledCatalogItems/d29efd6b-3cd6-4f8d-b1d8-da4ddd4e52b1/requests/template")
+                               .and_return(response)
+          allow(client).to receive(:http_get)
+                               .with("/catalog-service/api/consumer/entitledCatalogItems/3232323e-5443-4082-afd5-ab5a32939bbc/requests/template")
+                               .and_return(response)
+          allow(File).to receive(:write).with("vra_templates/d29efd6b-3cd6-4f8d-b1d8-da4ddd4e52b1.json", JSON.pretty_generate(catalog_item_payload))
+          allow(File).to receive(:write).with("vra_templates/3232323e-5443-4082-afd5-ab5a32939bbc.json", JSON.pretty_generate(catalog_item_payload))
+          allow(File).to receive(:write).with("vra_templates/windowsserver2012.json", JSON.pretty_generate(catalog_item_payload))
+          allow(File).to receive(:write).with("vra_templates/windowsserver2016.json", JSON.pretty_generate(catalog_item_payload))
+          allow(File).to receive(:write).with("custom_dir/windowsserver2012.json", JSON.pretty_generate(catalog_item_payload))
+          allow(File).to receive(:write).with("custom_dir/windowsserver2016.json", JSON.pretty_generate(catalog_item_payload))
+
+        end
+
+        it "#dump_templates" do
+          expect(described_class.dump_templates(client)).to eq(["vra_templates/windowsserver2012.json",
+                                                                "vra_templates/windowsserver2016.json"])
+        end
+
+        it "#dump_templates with custom directory" do
+          expect(described_class.dump_templates(client, "custom_dir")).to eq(["custom_dir/windowsserver2012.json",
+                                                                              "custom_dir/windowsserver2016.json"])
+        end
+
+        it "#dump_templates with id" do
+          expect(described_class.dump_templates(client, "vra_templates", true))
+              .to eq(["vra_templates/d29efd6b-3cd6-4f8d-b1d8-da4ddd4e52b1.json",
+                      "vra_templates/3232323e-5443-4082-afd5-ab5a32939bbc.json"])
+
+        end
+      end
+
+    end
+
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -27,6 +27,14 @@ describe Vra::Client do
                     base_url: "https://vra.corp.local")
   end
 
+  let(:client_without_ssl) do
+    Vra::Client.new(username: "user@corp.local",
+                    password: "password",
+                    tenant: "tenant",
+                    base_url: "https://vra.corp.local",
+                    verify_ssl: false)
+  end
+
   describe "#initialize" do
     it "calls validate_client_options!" do
       client = Vra::Client.allocate
@@ -204,6 +212,23 @@ describe Vra::Client do
         .and_return(response)
 
       client.http_head(path)
+    end
+
+    it "calls Vra::Http.execute with verify_ssl false" do
+      response   = double("response")
+      path       = "/test"
+      full_url   = "https://vra.corp.local/test"
+      headers    = { "Accept" => "application/json", "Content-Type" => "application/json" }
+      verify_ssl = false
+
+      allow(client_without_ssl).to receive(:authorize!)
+      expect(Vra::Http).to receive(:execute).with(method: :head,
+                                                  url: full_url,
+                                                  headers: headers,
+                                                  verify_ssl: verify_ssl)
+                               .and_return(response)
+
+      client_without_ssl.http_head(path)
     end
 
     it "raises an HTTPNotFound on a 404 error" do

--- a/spec/fixtures/catalog_request_template.json
+++ b/spec/fixtures/catalog_request_template.json
@@ -1,0 +1,130 @@
+{
+  "type": "com.vmware.vcac.catalog.domain.request.CatalogItemProvisioningRequest",
+  "catalogItemId": "7c8275d6-1bd6-452a-97c4-d6c053e4baa4",
+  "requestedFor": "csummers@example.com",
+  "businessGroupId": "c0683388-6db2-4cb5-9033-b24d15ad3766",
+  "description": null,
+  "reasons": null,
+  "data": {
+    "superduper_key": "superduper_value",
+    "Existing_Network_1": {
+      "componentTypeId": "com.vmware.csp.component.cafe.composition",
+      "componentId": null,
+      "classId": "Blueprint.Component.Declaration",
+      "typeFilter": "LinuxDemo*Existing_Network_1",
+      "data": {
+        "_cluster": 1,
+        "_hasChildren": false,
+        "description": null,
+        "name": "Existing Network",
+        "networkname": "Existing Network",
+        "subnetmask": "255.255.255.0"
+      }
+    },
+    "vSphere-Linux": {
+      "componentTypeId": "com.vmware.csp.component.cafe.composition",
+      "componentId": null,
+      "classId": "Blueprint.Component.Declaration",
+      "typeFilter": "LinuxDemo*vSphere-Linux",
+      "data": {
+        "Cafe.Shim.VirtualMachine.MaxCost": 0,
+        "Cafe.Shim.VirtualMachine.MinCost": 0,
+        "_cluster": 1,
+        "_hasChildren": false,
+        "action": "FullClone",
+        "allow_storage_policies": false,
+        "archive_days": 0,
+        "blueprint_type": "1",
+        "cpu": 1,
+        "custom_properties": [],
+        "daily_cost": 0,
+        "datacenter_location": null,
+        "description": null,
+        "disks": [
+          {
+            "componentTypeId": "com.vmware.csp.iaas.blueprint.service",
+            "componentId": null,
+            "classId": "Infrastructure.Compute.Machine.MachineDisk",
+            "typeFilter": null,
+            "data": {
+              "capacity": 6,
+              "id": 0,
+              "initial_location": "",
+              "is_clone": false,
+              "label": "",
+              "storage_reservation_policy": "",
+              "userCreated": true,
+              "volumeId": 0
+            }
+          }
+        ],
+        "display_location": false,
+        "guest_customization_specification": null,
+        "lease_days": 0,
+        "machine_actions": [
+          "DESTROY",
+          "POWER_ON",
+          "CONNECT_RDP_SSH",
+          "REPROVISION",
+          "POWER_CYCLE",
+          "EXPIRE",
+          "SUSPEND",
+          "CONNECT_REMOTE_CONSOLE",
+          "CONNECT_USING_VDI"
+        ],
+        "machine_prefix": {
+          "componentId": null,
+          "classId": "Infrastructure.Compute.MachinePrefix",
+          "id": "Use group default"
+        },
+        "max_network_adapters": 0,
+        "max_per_user": 0,
+        "max_volumes": 60,
+        "memory": 4096,
+        "nics": [
+          {
+            "componentTypeId": "com.vmware.csp.iaas.blueprint.service",
+            "componentId": null,
+            "classId": "Infrastructure.Compute.Machine.Nic",
+            "typeFilter": null,
+            "data": {
+              "address": "",
+              "assignment_type": "DHCP",
+              "custom_properties": null,
+              "id": 0,
+              "load_balancing": "",
+              "network_profile": "Existing Network"
+            }
+          }
+        ],
+        "number_of_instances": 1,
+        "os_arch": "x86_64",
+        "os_distribution": null,
+        "os_type": "Linux",
+        "os_version": null,
+        "platform_name": "vsphere",
+        "platform_type": "virtual",
+        "property_groups": [
+          null
+        ],
+        "provisioning_workflow": {
+          "componentId": null,
+          "classId": "Infrastructure.Compute.ProvisioningWorkflow",
+          "id": "CloneWorkflow"
+        },
+        "reservation_policy": {
+          "componentId": null,
+          "classId": "Infrastructure.Reservation.Policy.ComputeResource",
+          "id": "None"
+        },
+        "security_groups": [],
+        "security_tags": [],
+        "source_machine": null,
+        "source_machine_external_snapshot": null,
+        "source_machine_name": "cbpcentos_63_x86",
+        "source_machine_vmsnapshot": null,
+        "storage": 6
+      }
+    }
+  }
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,4 +20,11 @@
 require "vra"
 require "webmock/rspec"
 
+def fixtures_dir
+  @fixtures_dir ||= begin
+    base_dir = File.dirname(__FILE__)
+    File.join(base_dir, "fixtures")
+  end
+end
+
 WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
### Description

Adds ability to supply custom request templates from file.  If you have a bunch of 
saved catalog templates you can now just create catalog requests from those templates 
or even just merge in those templates with your current catalog request object.

Why is this important?  Test-kitchen automates this process for you.  But if you are not using this for some other project, you will eventually want to have this feature since trying to merge properties via set_parameter is very painful.  As noted in #54 

This MR also supersedes #56 since it was required to make this feature.  Merging this request negates the need to merge #56 

This MR also fixes some tests that were skipped in the catalog_request specs.

For an example catalog template, please see `spec/fixtures/catalog_request_template.json`
### Issues Resolved

N|A

### Check List

- [x] All tests pass.
- [x] All style checks pass.
- [x] Functionality includes testing.
- [x] Functionality has been documented in the README if applicable
