### PR TITLE
Fixes a bug with Resource.by_name

### DIFF
--- a/lib/vra/resource.rb
+++ b/lib/vra/resource.rb
@@ -50,7 +50,7 @@ module Vra
     def self.by_name(client, name)
       raise ArgumentError.new("name cannot be nil") if name.nil?
       raise ArgumentError.new("client cannot be nil") if client.nil?
-      Resources.all.find { |r| r.name.downcase =~ /#{name.downcase}/ }
+      Resources.all(client).find { |r| r.name.downcase =~ /#{name.downcase}/ }
     end
 
     def fetch_resource_data

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -72,7 +72,7 @@ describe Vra::Resource do
       resource = Vra::Resource.allocate
       allow(resource).to receive(:name).and_return("host1234")
       name = resource.name
-      allow(Vra::Resources).to receive(:all).and_return([resource])
+      expect(Vra::Resources).to receive(:all).with(client).and_return([resource])
       expect(Vra::Resource.by_name(client, name)).to eq(resource)
     end
 
@@ -80,7 +80,7 @@ describe Vra::Resource do
       resource = Vra::Resource.allocate
       allow(resource).to receive(:name).and_return("host1234")
       name = "somethingelse1234"
-      allow(Vra::Resources).to receive(:all).and_return([resource])
+      expect(Vra::Resources).to receive(:all).with(client).and_return([resource])
       expect(Vra::Resource.by_name(client, name)).to be nil
     end
   end


### PR DESCRIPTION
  * previously when Resources.all was called through by_name the call did not pass the
    required arguments.  This was due to a unit testing error where the
    complete call was mocked which would have caught this issue.


- [x ] All tests pass.
- [x ] All style checks pass.
- [x ] Functionality includes testing.
- [x ] Functionality has been documented in the README if applicable
