### PR TITLE
Updated client.http_post call

### DIFF
--- a/lib/vra/catalog_request.rb
+++ b/lib/vra/catalog_request.rb
@@ -113,7 +113,7 @@ module Vra
       validate_params!
 
       begin
-        post_response = client.http_post("/catalog-service/api/consumer/entitledCatalogItems/#{@catalog_id}/requests", template_payload)
+        post_response = client.http_post("/catalog-service/api/consumer/entitledCatalogItems/#{@catalog_id}/requests", merged_payload)
       rescue Vra::Exception::HTTPError => e
         raise Vra::Exception::RequestError, "Unable to submit request: #{e.errors.join(', ')}"
       rescue


### PR DESCRIPTION
Modified parameter in client.http_post call from template_payload to merged_payload.

### Description

In last update in lib/vra/catalog_request.rb, client.http_post parameter value has been changed from merged_payload to template_payload, so post request is submitted with template, instead of actual value  from input (.kitchen.yml)

### Issues Resolved

<!--- List any existing issues this PR resolves--->

### Check List

- [ ] All tests pass.
- [ ] All style checks pass.
- [ ] Functionality includes testing.
- [ ] Functionality has been documented in the README if applicable
