### PR TITLE
Add support for boolean vRA parameters, fix deep merge, add tracing

### DIFF
--- a/lib/vra/catalog_request.rb
+++ b/lib/vra/catalog_request.rb
@@ -18,6 +18,13 @@
 #
 require "vra/catalog_item"
 
+class ::Hash
+  def deep_merge(second)
+    merger = proc { |key, v1, v2| Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : v2 }
+    merge(second, &merger)
+  end
+end
+
 module Vra
   class CatalogRequest
     attr_reader :catalog_id, :catalog_item, :client, :custom_fields
@@ -96,7 +103,7 @@ module Vra
       hash_payload["requestedFor"] = @requested_for
       hash_payload["data"]["_leaseDays"] = @lease_days
       hash_payload["description"] = @notes
-      hash_payload["data"][blueprint_name]["data"].merge!(parameters["data"]) unless parameters.empty?
+      hash_payload["data"] = hash_payload["data"].deep_merge(parameters["data"]) unless parameters.empty?
       hash_payload.to_json
     end
 

--- a/lib/vra/http.rb
+++ b/lib/vra/http.rb
@@ -8,6 +8,11 @@ module Vra
       request = Request.new(params)
       response = request.call
       response = response.forward(request).call until response.final?
+      if ENV["VRA_HTTP_TRACE"]
+        puts "#{request.params[:method].upcase} #{request.params[:url]}" unless request.params.nil?
+        puts ">>>>> #{JSON.parse(request.params[:payload]).to_json}" unless request.params[:payload].nil?
+        puts "<<<<< #{JSON.parse(response.body).to_json}" unless response.body.nil?
+      end
       raise error(response) unless response.success?
       response
     end

--- a/lib/vra/request_parameters.rb
+++ b/lib/vra/request_parameters.rb
@@ -156,6 +156,8 @@ module Vra
         @value.to_i
       when "string"
         @value
+      when "boolean"
+        @value.to_s == "true"
       else
         @value
       end

--- a/spec/catalog_request_spec.rb
+++ b/spec/catalog_request_spec.rb
@@ -136,15 +136,18 @@ describe Vra::CatalogRequest do
       it "properly handles additional parameters" do
         request.set_parameter("param1", "string", "my string")
         request.set_parameter("param2", "integer", "2468")
+        request.set_parameter("param3", "boolean", "true")
 
         template = File.read("spec/fixtures/resource/catalog_request.json")
         payload = JSON.parse(request.merge_payload(template))
-        param1 = payload["data"]["my_blueprint"]["data"]["param1"]
-        param2 = payload["data"]["my_blueprint"]["data"]["param2"]
+        param1 = payload["data"]["param1"]
+        param2 = payload["data"]["param2"]
+        param3 = payload["data"]["param3"]
         expect(param1).to be_a(String)
         expect(param2).to be_a(Integer)
         expect(param1).to eq "my string"
         expect(param2).to eq 2468
+        expect(param3).to be_truthy
       end
 
       it "properly handles additional nested parameters" do
@@ -153,8 +156,8 @@ describe Vra::CatalogRequest do
 
         template = File.read("spec/fixtures/resource/catalog_request.json")
         payload = JSON.parse(request.merge_payload(template))
-        param1 = payload["data"]["my_blueprint"]["data"]["BP1"]["data"]["param1"]
-        param2 = payload["data"]["my_blueprint"]["data"]["BP1"]["data"]["BP2"]["data"]["param2"]
+        param1 = payload["data"]["BP1"]["data"]["param1"]
+        param2 = payload["data"]["BP1"]["data"]["BP2"]["data"]["param2"]
         expect(param1).to be_a(String)
         expect(param2).to be_a(Integer)
         expect(param1).to eq "my string"
@@ -183,8 +186,8 @@ describe Vra::CatalogRequest do
 
         template = File.read("spec/fixtures/resource/catalog_request.json")
         payload = JSON.parse(request.merge_payload(template))
-        param1 = payload["data"]["my_blueprint"]["data"]["BP1"]["data"]["param1"]
-        param2 = payload["data"]["my_blueprint"]["data"]["BP1"]["data"]["BP2"]["data"]["param2"]
+        param1 = payload["data"]["BP1"]["data"]["param1"]
+        param2 = payload["data"]["BP1"]["data"]["BP2"]["data"]["param2"]
 
         expect(param1).to be_a(String)
         expect(param2).to be_a(Integer)


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

This PR solves more of the deep merge problems being seen when used in combination with kitchen-vra. Previously, a request to submit a blueprint with custom parameters would retrieve the template from the vRA server and merge the data at the wrong level which meant that although the additional parameters were being seen by vRA, they were not overriding the correct values from the template.

This PR also adds support for boolean parameters that be set as input to a blueprint (in addition to the existing String, Integer support).

Finally we add a tracing capability (set `VRA_HTTP_TRACE=1` in your environment to activate) so that the API calls can be monitors when there are issues.

### Issues Resolved

Fixes #75 

### Check List

- [x] All tests pass.
- [x] All style checks pass.
- [x] Functionality includes testing.
- [x] Functionality has been documented in the README if applicable
