### PR TITLE
Added option to handle shirt size feature. Signed-off-by: Vinu Philip…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [2.7.2](https://github.com/chef-partners/vmware-vra-gem/tree/v2.7.2) (2020-09-09)
+[Full Changelog](https://github.com/chef-partners/vmware-vra-gem/compare/v2.7.1...v2.7.2)
+
+- Added an extra option to handle shirt size parameter
+- Masking user credentials(password) in debug mode
+
 ## [2.7.1](https://github.com/chef-partners/vmware-vra-gem/tree/v2.7.1) (2019-05-28)
 [Full Changelog](https://github.com/chef-partners/vmware-vra-gem/compare/v2.7.0...v2.7.1)
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ request_options = {
 # create the request
 catalog_request = vra.catalog.request(blueprint, request_options)
 ```
+In the above option instead of cpus and memory, shirt_size can be used as well if the blueprint has shirt size option enabled. e.g. of shirt size can be like value.small, value.medium etc, 
 
 Now, submit your request!  The client will return a new "Request" object you can use to query for status.
 

--- a/lib/vra/catalog_request.rb
+++ b/lib/vra/catalog_request.rb
@@ -29,13 +29,14 @@ module Vra
   class CatalogRequest
     attr_reader :catalog_id, :catalog_item, :client, :custom_fields
     attr_writer :subtenant_id, :template_payload
-    attr_accessor :cpus, :memory, :requested_for, :lease_days, :notes
+    attr_accessor :cpus, :memory, :shirt_size,  :requested_for, :lease_days, :notes
 
     def initialize(client, catalog_id, opts = {})
       @client            = client
       @catalog_id        = catalog_id
       @cpus              = opts[:cpus]
       @memory            = opts[:memory]
+      @shirt_size        = opts[:shirt_size]
       @requested_for     = opts[:requested_for]
       @lease_days        = opts[:lease_days]
       @notes             = opts[:notes]
@@ -55,6 +56,7 @@ module Vra
       opts = {}
       opts[:cpus] = blueprint_data["data"]["cpu"]
       opts[:memory] = blueprint_data["data"]["memory"]
+      opts[:shirt_size] = blueprint_data["data"]["size"]
       opts[:requested_for] = hash_payload["requestedFor"]
       opts[:lease_days] = blueprint_data.fetch("leaseDays", nil) || hash_payload["data"].fetch("_lease_days", 1)
       opts[:description] = hash_payload["description"]
@@ -100,6 +102,7 @@ module Vra
       blueprint_name = hash_payload["data"].select { |_k, v| v.is_a?(Hash) }.keys.first
       hash_payload["data"][blueprint_name]["data"]["cpu"] = @cpus
       hash_payload["data"][blueprint_name]["data"]["memory"] = @memory
+      hash_payload["data"][blueprint_name]["data"]["size"] = @shirt_size
       hash_payload["requestedFor"] = @requested_for
       hash_payload["data"]["_leaseDays"] = @lease_days
       hash_payload["description"] = @notes

--- a/lib/vra/http.rb
+++ b/lib/vra/http.rb
@@ -10,7 +10,7 @@ module Vra
       response = response.forward(request).call until response.final?
       if ENV["VRA_HTTP_TRACE"]
         puts "#{request.params[:method].upcase} #{request.params[:url]}" unless request.params.nil?
-        puts ">>>>> #{JSON.parse(request.params[:payload]).to_json}" unless request.params[:payload].nil?
+        puts ">>>>> #{JSON.parse(request.params[:payload]).to_json.gsub(/\"password\":\"(.+)\",/,'"password":"********",' )}" unless request.params[:payload].nil?
         puts "<<<<< #{JSON.parse(response.body).to_json}" unless response.body.nil?
       end
       raise error(response) unless response.success?

--- a/lib/vra/version.rb
+++ b/lib/vra/version.rb
@@ -18,5 +18,5 @@
 #
 
 module Vra
-  VERSION = "2.7.1"
+  VERSION = "2.7.2"
 end


### PR DESCRIPTION
Signed-off-by: Vinu Philip <vinu.philip@gmail.com>

### Description

This change is to support the handling of shirt size option of vRA, so that users can enter the shirt size value (combination of CPU, RAM and Storage) of the desired VM they wish to provision, provided the blueprint they wish to provision has the shirt size option set up.

Also user credentials (password) was displayed in plain text in Debug mode. This addresses the problem by masking the password.


### Issues Resolved

None. This is just an enhancement

### Check List

- [Y] All tests pass.
- [Y] All style checks pass.
- [Y] Functionality includes testing.
- [Y] Functionality has been documented in the README if applicable
